### PR TITLE
Readme: add missing dot to .mime.types

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Firefox may not know how to handle markdown files by default (see #2), and if op
    - use a directory accessible to firefox, and
    - expand the `~` to the full path of your home
 
-   E.g. use as filename and config value: `/home/<me>/snap/firefox/common/mime.types` − where `<me>` is your username.
+   E.g. use as filename and config value: `/home/<me>/snap/firefox/common/.mime.types` − where `<me>` is your username.
    A suitable directory is likely the parent of `.mozilla` in your profile path, which you can find in `about:profiles`.
 
    ---


### PR DESCRIPTION
The hack only worked for me if the file was `.mime.types` (with a leading period).

Related: I noticed that https://github.com/asciidoctor/asciidoctor-browser-extension somehow works on plain text Asciidoc files without this or other hacks. 🤷

Also mentioned at https://github.com/Cimbali/markdown-viewer/issues/86#issuecomment-1900771576